### PR TITLE
Move frontend coverage to Codecov

### DIFF
--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -25,8 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run coverage
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./frontend/coverage/lcov.info
+      - name: Upload to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Build with Maven
         env:
           TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: mvn -B test jacoco:report
       - name: Upload to Codecov
         env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Demo Spring React App
 
-[![Frontend Coverage](https://coveralls.io/repos/github/ucsb-cs156-f20/demo-spring-nextjs-app/badge.svg?branch=master)](https://coveralls.io/github/ucsb-cs156-f20/demo-spring-nextjs-app?branch=master)
-[![Backend Coverage](https://codecov.io/gh/ucsb-cs156-f20/demo-spring-nextjs-app/branch/master/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/demo-spring-nextjs-app)
+[![Codecov Coverage](https://codecov.io/gh/ucsb-cs156-f20/demo-spring-nextjs-app/branch/master/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/demo-spring-nextjs-app)
 
 A demo todo app with Spring Boot and Create React App.
 


### PR DESCRIPTION
This PR redirects frontend coverage publishing to Codecov, as it does a better job of automatically merging coverage reports.